### PR TITLE
Feature/create dataset backward compat dhis v20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history
+.rake_tasks~

--- a/dhis2.gemspec
+++ b/dhis2.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "faker", "~> 1.6", ">= 1.6.3"
+  spec.add_development_dependency "byebug"
+
 end

--- a/lib/dhis2/api/base.rb
+++ b/lib/dhis2/api/base.rb
@@ -93,12 +93,12 @@ module Dhis2
       end
 
       def add_relation(relation, relation_id)
-        client.post("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+        client.post("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}",{})
         self
       end
 
       def remove_relation(relation, relation_id)
-        client.delete("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+        client.delete("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}",{})
         self
       end
 

--- a/lib/dhis2/api/base.rb
+++ b/lib/dhis2/api/base.rb
@@ -92,6 +92,14 @@ module Dhis2
         self
       end
 
+      def add_relation(relation, relation_id)
+        client.post("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+      end
+
+      def remove_relation(relation, relation_id)
+        client.delete("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+      end
+
       def delete
         client.delete("#{self.class.resource_name}/#{id}")
         true

--- a/lib/dhis2/api/base.rb
+++ b/lib/dhis2/api/base.rb
@@ -94,10 +94,12 @@ module Dhis2
 
       def add_relation(relation, relation_id)
         client.post("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+        self
       end
 
       def remove_relation(relation, relation_id)
         client.delete("#{self.class.resource_name}/#{id}/#{relation}/#{relation_id}", attributes)
+        self
       end
 
       def delete

--- a/lib/dhis2/api/data_set.rb
+++ b/lib/dhis2/api/data_set.rb
@@ -6,19 +6,21 @@ module Dhis2
         def create(client, sets)
           sets = [sets].flatten
 
-          category_combo_id = client.category_combos.find_by(name: "default").id
+          category_combo = client.category_combos.find_by(name: "default")
 
           data_set = {
             data_sets: sets.map do |set|
-              {
+              dataset = {
                 name:               set[:name],
                 short_name:         set[:short_name],
                 code:               set[:code],
                 period_type:        "Monthly",
-                data_elements:      set[:data_element_ids] ? set[:data_element_ids].map { |id| { id: id } } : [],
+                data_elements:  set[:data_element_ids] ? set[:data_element_ids].map { |id| { id: id } } : [],
                 organisation_units: set[:organisation_unit_ids] ? set[:organisation_unit_ids].map { |id| { id: id } } : [],
-                category_combo:     { id: category_combo_id }
+                category_combo:     { id: category_combo.id, name: category_combo.name }
               }
+
+              dataset
             end
           }
           response = client.post("metadata", data_set)

--- a/test/data_set_test.rb
+++ b/test/data_set_test.rb
@@ -30,6 +30,41 @@ class DataSetTest < Minitest::Test
     assert_equal "TTT#{one}", data_set_1.short_name
   end
 
+
+  def test_add_remove_from_relation
+    data_set = Dhis2.client.data_sets.list(page_size:1).first
+    data_element = Dhis2.client.data_elements.list(page_size: 1).first
+    begin
+      data_set.remove_relation(:dataSetElements, data_element.id)
+    rescue => ignored
+    end
+
+    data_set.add_relation(:dataSetElements, data_element.id)
+    data_set = Dhis2.client.data_sets.find(data_set.id)
+    puts data_element_ids(data_set).to_json
+    puts Dhis2.client.data_elements.list(page_size: 1).first
+
+    #assert_includes(data_element_ids(data_set), data_element.id)
+    # this is broken on play, looks like dataSetElements are a new resources
+    # dataSetElements vs dataElements
+    #  <dataElement id="wHngffm5bZU" name="Personnel administrative establishment" created="2013-06-27T00:00:00.000+0000" lastUpdated="2017-01-05T10:52:56.501+0000" href="http://dhis2-zw-sandbox.herokuapp.com/api/dataElements/wHngffm5bZU"/>
+    # so doesn't work as expected yet
+    # <dataSetElement created="2016-10-05T16:22:41.006" lastUpdated="2016-10-05T16:22:41.006" id="IJnZ0OyOUNT">
+    #  <externalAccess>false</externalAccess>
+     # <dataElement id="YgsAnqU3I7B"/>
+    #  <dataSet id="lyLU2wR22tC"/>
+    #  </dataSetElement>
+    # but the resource is not yet known
+    data_set.remove_relation(:dataSetElements, data_element.id)
+    data_set = Dhis2.client.data_sets.find(data_set.id)
+    puts data_element_ids(data_set).to_json
+
+  end
+
+  def data_element_ids(data_set)
+    data_set.data_set_elements.map{|e| e["data_element"]}.map{|de| de["id"]}
+  end
+
   def test_create_data_sets_with_links
     random = Random.new
     one = random.rand(10_000)

--- a/test/data_set_test.rb
+++ b/test/data_set_test.rb
@@ -38,8 +38,8 @@ class DataSetTest < Minitest::Test
     sets          = [
       {
         name:                  "FullTestT#{one}",
-        code:                  "FTT#{one}",
-        short_name:            "FTT#{one}",
+        code:                  "FullTestT#{one}",
+        short_name:            "FullTestT#{one}",
         data_element_ids:      data_elements.map(&:id),
         organisation_unit_ids: org_units.map(&:id)
       }
@@ -48,7 +48,7 @@ class DataSetTest < Minitest::Test
     assert_equal true, status.success?
     assert_equal 1, status.total_imported
 
-    created_set = Dhis2.client.data_sets.list(filter:"code:eq:FTT#{one}", fields: ":all").first
+    created_set = Dhis2.client.data_sets.list(filter:"code:eq:FullTestT#{one}", fields: ":all").first
     refute_empty created_set.organisation_units
 
     data_element1 = Dhis2.client.data_elements.find(data_elements.first.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ require "minitest/autorun"
 require "minitest/reporters"
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
+require "byebug"
+
 Dhis2.configure do |config|
   config.url      = "https://play.dhis2.org/demo"
   config.user     = "admin"


### PR DESCRIPTION
for backward compatibility we need to pass the id and name of default category 2.20

the add|remove_relation is working on older version for dataElements but not on recent one

to update dataElement membership in a dataSet
looks the relation/collection dataElements has been removed since 2.25 or 2.26
not yet clear how to create them now. A new resource dateSetElement is now advertised in the api but no endpoint is responding

I was able to remove a dataElement from a dataset 
via a curl delete https://play.dhis2.org/demo/api/dataSets/lyLU2wR22tC/dataSetElements/{id of the identifiableObject not the dataElement id} 
not found yet how to add it back

I will give it 1 hour find out...