### PR TITLE
Prevent map nil exception when no datavalues returned

### DIFF
--- a/lib/dhis2/api/shared/data_value_set.rb
+++ b/lib/dhis2/api/shared/data_value_set.rb
@@ -14,8 +14,12 @@ module Dhis2
             if raw
               response["dataValues"]
             else
-              response["data_values"].map do |elt|
-                OpenStruct.new(elt)
+              if response["data_values"]
+                response["data_values"].map do |elt|
+                  OpenStruct.new(elt)
+                end
+              else
+                []
               end
             end
           end
@@ -46,9 +50,9 @@ module Dhis2
           end
 
           def additional_query_parameters
-            [
-              :data_set, :data_element_group, :period, :start_date, :end_date,
-              :org_unit, :children, :org_unit_group
+            %i[
+              data_set data_element_group period start_date end_date
+              org_unit children org_unit_group
             ]
           end
         end


### PR DESCRIPTION
looks like a behaviour in most versions (experienced in 2.26 and reproduced on play 2.27 2.28 2.29)
https://play.dhis2.org/2.27/api/dataValueSets.json?dataSet=vc6nF5yZsPR&orgUnit=DiszpKrYNg8&period=201101

to be honest don't know how to add test with the test setup but will do.
the listable shared example is shared... need to figure it out how the shared example options work 

