### PR TITLE
removed cc id validation from 225 data_element creation

### DIFF
--- a/lib/dhis2/api/version225/data_element.rb
+++ b/lib/dhis2/api/version225/data_element.rb
@@ -24,9 +24,6 @@ module Dhis2
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version225::Constants.value_types
           )
-          required(:category_combo).schema do
-            required(:id).filled
-          end
         end
 
         def self.creation_defaults(args)


### PR DESCRIPTION
data element creation: removed the category combo[:id] validation from the gem to let dhis2 do the validation.
The id can indeed be provided as category_combo["id"] (and not :id ).
In 2.25 an error message is thrown by dhis2 (while in 2.26+ it takes the default cc)