### PR TITLE
Generic analytics

### DIFF
--- a/dhis2.gemspec
+++ b/dhis2.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "webmock", "3.1.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "< 0.18.0"
   spec.add_development_dependency "rest-client-logger"
 end

--- a/lib/dhis2/api/shared/analytic.rb
+++ b/lib/dhis2/api/shared/analytic.rb
@@ -4,11 +4,10 @@ module Dhis2
   module Api
     module Shared
       class Analytic
-        def self.list(client, periods:, organisation_units:, data_elements: nil, filter: nil, raw: false)
-          params = [
-            [:dimension, "ou:#{organisation_units}"],
-            [:dimension, "pe:#{periods}"]
-          ]
+        def self.list(client, periods: nil, organisation_units: nil, data_elements: nil, filter: nil, raw: false)
+          params = []
+          params << [:dimension, "pe:#{periods}"] if periods
+          params << [:dimension, "ou:#{organisation_units}"] if organisation_units
           params << [:dimension, "dx:#{data_elements}"] if data_elements
           params << [:filter, filter.to_s] if filter
 

--- a/lib/dhis2/api/shared/analytic.rb
+++ b/lib/dhis2/api/shared/analytic.rb
@@ -4,8 +4,9 @@ module Dhis2
   module Api
     module Shared
       class Analytic
-        def self.list(client, periods: nil, organisation_units: nil, data_elements: nil, filter: nil, raw: false)
+        def self.list(client, periods: nil, organisation_units: nil, data_elements: nil, filter: nil, raw: false, skipMeta: false)
           params = []
+          params << [:skipMeta, "true"] if skipMeta
           params << [:dimension, "pe:#{periods}"] if periods
           params << [:dimension, "ou:#{organisation_units}"] if organisation_units
           params << [:dimension, "dx:#{data_elements}"] if data_elements

--- a/spec/support/analytic_shared_example.rb
+++ b/spec/support/analytic_shared_example.rb
@@ -17,6 +17,16 @@ RSpec.shared_examples "an analytic endpoint" do |version:|
     )
   end
 
+  it "list by dx only, filtering on ou, pe" do
+    stub_request(:get, "https://play.dhis2.org/demo/api/analytics?dimension=dx:%5B%22de-987%22%5D&filter=ou:123%3B456,pe:201801%3B201802")
+      .to_return(status: 200, body: "", headers: {})
+
+    client.analytics.list(
+      data_elements: ["de-987"],
+      filter:        "ou:123;456,pe:201801;201802",
+    )    
+  end
+
   context "with stubbed data" do
     let(:data_element_id) { "h0xKKjijTdI" }
     let(:organisation_unit_id) { "vWbkYPRmKyS" }

--- a/spec/support/analytic_shared_example.rb
+++ b/spec/support/analytic_shared_example.rb
@@ -65,5 +65,28 @@ RSpec.shared_examples "an analytic endpoint" do |version:|
       stub_request(:get, "https://play.dhis2.org/demo/api/analytics?dimension=ou%3AvWbkYPRmKyS&dimension=pe%3A2016&dimension=dx%3Ah0xKKjijTdI")
         .to_return(status: 200, body: shared_content("analytics.json"))
     end
+
+    context "with skip meta option" do
+
+      before do
+        stub_api_skip_meta_request
+      end
+
+      it "adds the skipMeta query param " do
+        expect { client.analytics.list(
+          data_elements:      data_element_id,
+          organisation_units: organisation_unit_id,
+          periods:            period,
+          skipMeta:           true,
+          raw:                true
+        )}.not_to raise_error
+      end
+    end
+
+
+    def stub_api_skip_meta_request
+      stub_request(:get, "https://play.dhis2.org/demo/api/analytics?dimension=ou%3AvWbkYPRmKyS&dimension=pe%3A2016&dimension=dx%3Ah0xKKjijTdI&skipMeta=true")
+        .to_return(status: 200)
+    end
   end
 end


### PR DESCRIPTION
Avoid to force pe and ou as dimension in analytics queries.

Example of valid and meaningfull query:
https://play.dhis2.org/2.30/api/analytics.xml?dimension=dx:fbfJHSPpUQD&filter=ou:DiszpKrYNg8;g8upMTyEZGZ,pe:201801;201802

