### PR TITLE
Supporting newer rubies

### DIFF
--- a/dhis2.gemspec
+++ b/dhis2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rest-client"
-  spec.add_dependency "dry-validation", "0.11.1"
+  spec.add_dependency "dry-schema", "~> 1.9.1"
 
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters"

--- a/lib/dhis2.rb
+++ b/lib/dhis2.rb
@@ -6,7 +6,7 @@ require "ostruct"
 require "uri"
 require "delegate"
 require "cgi"
-require "dry-validation"
+require "dry-schema"
 
 require_relative "dhis2/version"
 require_relative "dhis2/case"

--- a/lib/dhis2/api/creatable.rb
+++ b/lib/dhis2/api/creatable.rb
@@ -38,7 +38,7 @@ module Dhis2
           if validator.success?
             yield
           else
-            raise Dhis2::CreationError, "Validation Error: #{validator.messages}"
+            raise Dhis2::CreationError, "Validation Error: #{validator.errors.to_h}"
           end
         end
       end

--- a/lib/dhis2/api/shared/category.rb
+++ b/lib/dhis2/api/shared/category.rb
@@ -11,9 +11,9 @@ module Dhis2
 
         def default
           self.class.default(client)
-        end        
+        end
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Constants::DATA_DIMENSION_TYPES
@@ -25,8 +25,8 @@ module Dhis2
             "categories"
           end
           def default(client)
-            find_by(client, name: "default")
-          end          
+            find_by(client, {name: "default"})
+          end
           def creation_defaults(args)
             {
               data_dimension_type: "DISAGGREGATION"

--- a/lib/dhis2/api/shared/category_combo.rb
+++ b/lib/dhis2/api/shared/category_combo.rb
@@ -14,7 +14,7 @@ module Dhis2
 
         module ClassMethods
           def default(client)
-            find_by(client, name: "default")
+            find_by(client, {name: "default"})
           end
 
           private

--- a/lib/dhis2/api/shared/category_option.rb
+++ b/lib/dhis2/api/shared/category_option.rb
@@ -5,7 +5,7 @@ module Dhis2
   module Api
     module Shared
       module CategoryOption
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
         def self.included(base)
@@ -14,12 +14,12 @@ module Dhis2
 
         def default
           self.class.default(client)
-        end        
+        end
 
         module ClassMethods
           def default(client)
-            find_by(client, name: "default")
-          end          
+            find_by(client, {name: "default"})
+          end
         end
       end
     end

--- a/lib/dhis2/api/shared/category_option_combo.rb
+++ b/lib/dhis2/api/shared/category_option_combo.rb
@@ -14,7 +14,7 @@ module Dhis2
 
         module ClassMethods
           def default(client)
-            find_by(client, name: "default")
+            find_by(client, {name: "default"})
           end
         end
       end

--- a/lib/dhis2/api/version224/attribute.rb
+++ b/lib/dhis2/api/version224/attribute.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version224::Constants.value_types

--- a/lib/dhis2/api/version224/category_combo.rb
+++ b/lib/dhis2/api/version224/category_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::CategoryCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Version224::Constants.data_dimension_types

--- a/lib/dhis2/api/version224/category_option_combo.rb
+++ b/lib/dhis2/api/version224/category_option_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::CategoryOptionCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:category_combo).schema do
             required(:id).filled
           end

--- a/lib/dhis2/api/version224/data_element.rb
+++ b/lib/dhis2/api/version224/data_element.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:aggregation_type).value(

--- a/lib/dhis2/api/version224/data_element_group.rb
+++ b/lib/dhis2/api/version224/data_element_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::DataElementGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/data_set.rb
+++ b/lib/dhis2/api/version224/data_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:period_type).value(
             included_in?: ::Dhis2::Api::Version224::Constants.period_types

--- a/lib/dhis2/api/version224/data_value_set.rb
+++ b/lib/dhis2/api/version224/data_value_set.rb
@@ -9,7 +9,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::DataValueSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:data_values).each do
             schema do
               required(:value).filled

--- a/lib/dhis2/api/version224/event.rb
+++ b/lib/dhis2/api/version224/event.rb
@@ -16,11 +16,11 @@ module Dhis2
 
         # args for a program without registration
         # and a  program with a program_stage
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:program).filled # program must be linked to the org unit
           required(:org_unit).filled
           required(:event_date).filled
-          required(:data_values).each do
+          required(:data_values).array(:hash) do
             required(:data_element).filled
             required(:value).filled
           end

--- a/lib/dhis2/api/version224/indicator.rb
+++ b/lib/dhis2/api/version224/indicator.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:numerator).filled

--- a/lib/dhis2/api/version224/indicator_group.rb
+++ b/lib/dhis2/api/version224/indicator_group.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/indicator_type.rb
+++ b/lib/dhis2/api/version224/indicator_type.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/organisation_unit.rb
+++ b/lib/dhis2/api/version224/organisation_unit.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnit
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:opening_date).filled

--- a/lib/dhis2/api/version224/organisation_unit_group.rb
+++ b/lib/dhis2/api/version224/organisation_unit_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnitGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/organisation_unit_group_set.rb
+++ b/lib/dhis2/api/version224/organisation_unit_group_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/organisation_unit_level.rb
+++ b/lib/dhis2/api/version224/organisation_unit_level.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:level).filled
         end

--- a/lib/dhis2/api/version224/program.rb
+++ b/lib/dhis2/api/version224/program.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:program_type).value(
             included_in?: ::Dhis2::Api::Version224::Constants.program_types

--- a/lib/dhis2/api/version224/report.rb
+++ b/lib/dhis2/api/version224/report.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Version224::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version224/report_table.rb
+++ b/lib/dhis2/api/version224/report_table.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Version224::SaveValidator
         include ::Dhis2::Api::Shared::ReportTable
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/attribute.rb
+++ b/lib/dhis2/api/version225/attribute.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version225::Constants.value_types

--- a/lib/dhis2/api/version225/category_combo.rb
+++ b/lib/dhis2/api/version225/category_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Version225::Constants.data_dimension_types

--- a/lib/dhis2/api/version225/category_option_combo.rb
+++ b/lib/dhis2/api/version225/category_option_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryOptionCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:category_combo).schema do
             required(:id).filled
           end

--- a/lib/dhis2/api/version225/data_element.rb
+++ b/lib/dhis2/api/version225/data_element.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:aggregation_type).value(

--- a/lib/dhis2/api/version225/data_element_group.rb
+++ b/lib/dhis2/api/version225/data_element_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataElementGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/data_set.rb
+++ b/lib/dhis2/api/version225/data_set.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:period_type).value(
             included_in?: ::Dhis2::Api::Version225::Constants.period_types

--- a/lib/dhis2/api/version225/data_value_set.rb
+++ b/lib/dhis2/api/version225/data_value_set.rb
@@ -9,7 +9,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataValueSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:data_values).each do
             schema do
               required(:value).filled

--- a/lib/dhis2/api/version225/event.rb
+++ b/lib/dhis2/api/version225/event.rb
@@ -18,11 +18,11 @@ module Dhis2
 
         # args for a program without registration
         # and a  program with a program_stage
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:program).filled # program must be linked to the org unit
           required(:org_unit).filled
           required(:event_date).filled
-          required(:data_values).each do
+          required(:data_values).array(:hash) do
             required(:data_element).filled
             required(:value).filled
           end

--- a/lib/dhis2/api/version225/indicator.rb
+++ b/lib/dhis2/api/version225/indicator.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:numerator).filled

--- a/lib/dhis2/api/version225/indicator_group.rb
+++ b/lib/dhis2/api/version225/indicator_group.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/indicator_type.rb
+++ b/lib/dhis2/api/version225/indicator_type.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/organisation_unit.rb
+++ b/lib/dhis2/api/version225/organisation_unit.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnit
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:opening_date).filled

--- a/lib/dhis2/api/version225/organisation_unit_group.rb
+++ b/lib/dhis2/api/version225/organisation_unit_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnitGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/organisation_unit_group_set.rb
+++ b/lib/dhis2/api/version225/organisation_unit_group_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/organisation_unit_level.rb
+++ b/lib/dhis2/api/version225/organisation_unit_level.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:level).filled
         end

--- a/lib/dhis2/api/version225/program.rb
+++ b/lib/dhis2/api/version225/program.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:program_type).value(
             included_in?: ::Dhis2::Api::Version225::Constants.program_types

--- a/lib/dhis2/api/version225/report.rb
+++ b/lib/dhis2/api/version225/report.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version225/report_table.rb
+++ b/lib/dhis2/api/version225/report_table.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::ReportTable
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/attribute.rb
+++ b/lib/dhis2/api/version226/attribute.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version226::Constants.value_types

--- a/lib/dhis2/api/version226/category_combo.rb
+++ b/lib/dhis2/api/version226/category_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Version226::Constants.data_dimension_types

--- a/lib/dhis2/api/version226/category_option_combo.rb
+++ b/lib/dhis2/api/version226/category_option_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryOptionCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:category_combo).schema do
             required(:id).filled
           end

--- a/lib/dhis2/api/version226/data_element.rb
+++ b/lib/dhis2/api/version226/data_element.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:aggregation_type).value(

--- a/lib/dhis2/api/version226/data_element_group.rb
+++ b/lib/dhis2/api/version226/data_element_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataElementGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/data_set.rb
+++ b/lib/dhis2/api/version226/data_set.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:period_type).value(
             included_in?: ::Dhis2::Api::Version226::Constants.period_types

--- a/lib/dhis2/api/version226/data_value_set.rb
+++ b/lib/dhis2/api/version226/data_value_set.rb
@@ -9,7 +9,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataValueSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:data_values).each do
             schema do
               required(:value).filled

--- a/lib/dhis2/api/version226/event.rb
+++ b/lib/dhis2/api/version226/event.rb
@@ -18,11 +18,11 @@ module Dhis2
 
         # args for a program without registration
         # and a  program with a program_stage
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:program).filled # program must be linked to the org unit
           required(:org_unit).filled
           required(:event_date).filled
-          required(:data_values).each do
+          required(:data_values).array(:hash) do
             required(:data_element).filled
             required(:value).filled
           end

--- a/lib/dhis2/api/version226/indicator.rb
+++ b/lib/dhis2/api/version226/indicator.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:numerator).filled

--- a/lib/dhis2/api/version226/indicator_group.rb
+++ b/lib/dhis2/api/version226/indicator_group.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/indicator_type.rb
+++ b/lib/dhis2/api/version226/indicator_type.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/organisation_unit.rb
+++ b/lib/dhis2/api/version226/organisation_unit.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnit
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:opening_date).filled

--- a/lib/dhis2/api/version226/organisation_unit_group.rb
+++ b/lib/dhis2/api/version226/organisation_unit_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnitGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/organisation_unit_group_set.rb
+++ b/lib/dhis2/api/version226/organisation_unit_group_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/organisation_unit_level.rb
+++ b/lib/dhis2/api/version226/organisation_unit_level.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:level).filled
         end

--- a/lib/dhis2/api/version226/program.rb
+++ b/lib/dhis2/api/version226/program.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:program_type).value(

--- a/lib/dhis2/api/version226/report.rb
+++ b/lib/dhis2/api/version226/report.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version226/report_table.rb
+++ b/lib/dhis2/api/version226/report_table.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::ReportTable
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/attribute.rb
+++ b/lib/dhis2/api/version227/attribute.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version227::Constants.value_types

--- a/lib/dhis2/api/version227/category_combo.rb
+++ b/lib/dhis2/api/version227/category_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Version227::Constants.data_dimension_types

--- a/lib/dhis2/api/version227/category_option_combo.rb
+++ b/lib/dhis2/api/version227/category_option_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryOptionCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:category_combo).schema do
             required(:id).filled
           end

--- a/lib/dhis2/api/version227/data_element.rb
+++ b/lib/dhis2/api/version227/data_element.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:aggregation_type).value(

--- a/lib/dhis2/api/version227/data_element_group.rb
+++ b/lib/dhis2/api/version227/data_element_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataElementGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/data_set.rb
+++ b/lib/dhis2/api/version227/data_set.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:period_type).value(
             included_in?: ::Dhis2::Api::Version227::Constants.period_types

--- a/lib/dhis2/api/version227/data_value_set.rb
+++ b/lib/dhis2/api/version227/data_value_set.rb
@@ -9,7 +9,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataValueSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:data_values).each do
             schema do
               required(:value).filled

--- a/lib/dhis2/api/version227/event.rb
+++ b/lib/dhis2/api/version227/event.rb
@@ -18,11 +18,11 @@ module Dhis2
 
         # args for a program without registration
         # and a  program with a program_stage
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:program).filled # program must be linked to the org unit
           required(:org_unit).filled
           required(:event_date).filled
-          required(:data_values).each do
+          required(:data_values).array(:hash) do
             required(:data_element).filled
             required(:value).filled
           end

--- a/lib/dhis2/api/version227/indicator.rb
+++ b/lib/dhis2/api/version227/indicator.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:numerator).filled

--- a/lib/dhis2/api/version227/indicator_group.rb
+++ b/lib/dhis2/api/version227/indicator_group.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/indicator_type.rb
+++ b/lib/dhis2/api/version227/indicator_type.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/organisation_unit.rb
+++ b/lib/dhis2/api/version227/organisation_unit.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnit
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:opening_date).filled

--- a/lib/dhis2/api/version227/organisation_unit_group.rb
+++ b/lib/dhis2/api/version227/organisation_unit_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnitGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/organisation_unit_group_set.rb
+++ b/lib/dhis2/api/version227/organisation_unit_group_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/organisation_unit_level.rb
+++ b/lib/dhis2/api/version227/organisation_unit_level.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:level).filled
         end

--- a/lib/dhis2/api/version227/program.rb
+++ b/lib/dhis2/api/version227/program.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:program_type).value(

--- a/lib/dhis2/api/version227/report.rb
+++ b/lib/dhis2/api/version227/report.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version227/report_table.rb
+++ b/lib/dhis2/api/version227/report_table.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::ReportTable
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/attribute.rb
+++ b/lib/dhis2/api/version228/attribute.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:value_type).value(
             included_in?: ::Dhis2::Api::Version228::Constants.value_types

--- a/lib/dhis2/api/version228/category_combo.rb
+++ b/lib/dhis2/api/version228/category_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:data_dimension_type).value(
             included_in?: ::Dhis2::Api::Version228::Constants.data_dimension_types

--- a/lib/dhis2/api/version228/category_option_combo.rb
+++ b/lib/dhis2/api/version228/category_option_combo.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::CategoryOptionCombo
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:category_combo).schema do
             required(:id).filled
           end

--- a/lib/dhis2/api/version228/data_element.rb
+++ b/lib/dhis2/api/version228/data_element.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:aggregation_type).value(

--- a/lib/dhis2/api/version228/data_element_group.rb
+++ b/lib/dhis2/api/version228/data_element_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataElementGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/data_set.rb
+++ b/lib/dhis2/api/version228/data_set.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:period_type).value(
             included_in?: ::Dhis2::Api::Version228::Constants.period_types

--- a/lib/dhis2/api/version228/data_value_set.rb
+++ b/lib/dhis2/api/version228/data_value_set.rb
@@ -9,7 +9,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::DataValueSet
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:data_values).each do
             schema do
               required(:value).filled

--- a/lib/dhis2/api/version228/event.rb
+++ b/lib/dhis2/api/version228/event.rb
@@ -18,11 +18,11 @@ module Dhis2
 
         # args for a program without registration
         # and a  program with a program_stage
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:program).filled # program must be linked to the org unit
           required(:org_unit).filled
           required(:event_date).filled
-          required(:data_values).each do
+          required(:data_values).array(:hash) do
             required(:data_element).filled
             required(:value).filled
           end

--- a/lib/dhis2/api/version228/indicator.rb
+++ b/lib/dhis2/api/version228/indicator.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:numerator).filled

--- a/lib/dhis2/api/version228/indicator_group.rb
+++ b/lib/dhis2/api/version228/indicator_group.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/indicator_type.rb
+++ b/lib/dhis2/api/version228/indicator_type.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/organisation_unit.rb
+++ b/lib/dhis2/api/version228/organisation_unit.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnit
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:opening_date).filled

--- a/lib/dhis2/api/version228/organisation_unit_group.rb
+++ b/lib/dhis2/api/version228/organisation_unit_group.rb
@@ -13,7 +13,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::OrganisationUnitGroup
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/organisation_unit_group_set.rb
+++ b/lib/dhis2/api/version228/organisation_unit_group_set.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/organisation_unit_level.rb
+++ b/lib/dhis2/api/version228/organisation_unit_level.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:level).filled
         end

--- a/lib/dhis2/api/version228/program.rb
+++ b/lib/dhis2/api/version228/program.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
           required(:short_name).filled
           required(:program_type).value(

--- a/lib/dhis2/api/version228/report.rb
+++ b/lib/dhis2/api/version228/report.rb
@@ -11,7 +11,7 @@ module Dhis2
         include ::Dhis2::Api::Deletable
         include ::Dhis2::Api::Shared::SaveValidator
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/api/version228/report_table.rb
+++ b/lib/dhis2/api/version228/report_table.rb
@@ -12,7 +12,7 @@ module Dhis2
         include ::Dhis2::Api::Shared::SaveValidator
         include ::Dhis2::Api::Shared::ReportTable
 
-        Schema = Dry::Validation.Schema do
+        Schema = Dry::Schema.define do
           required(:name).filled
         end
       end

--- a/lib/dhis2/collection_wrapper.rb
+++ b/lib/dhis2/collection_wrapper.rb
@@ -7,9 +7,9 @@ module Dhis2
       @client = client
     end
 
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       args = args.unshift(@client)
-      @klass.public_send(method_name, *args, &block)
+      @klass.public_send(method_name, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(method_name)


### PR DESCRIPTION
This is a work progress.

Currently it only supports ruby 3 (and probably 2.7 as well), but it won't support < 2.7, so before we can merge this, that will need to be fixed as well.

So todos:

- [ ] CI
- [ ] CI for multiple rubies
- [ ] Support method_missing for < 2.7 and > 2.7